### PR TITLE
Inspect qemu monitor to verify rbd is used

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for ansible-role-qemu-ceph-clients
+script_debug_output: false
+exclude_qemu_without_rbd: false

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -13,7 +13,7 @@ usage() {
   echo "" 1>&2;
   echo "  -o, expected old ceph version" 1>&2;
   echo "  -n, expected new ceph version" 1>&2;
-  echo "  -e, exclude VMs with no RBDs present" 1>&2;
+  echo "  -e, exclude QEMUs with no RBDs present" 1>&2;
   echo "  -d, debug" 1>&2;
   echo "" 1>&2;
   exit 1

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -37,6 +37,8 @@ for PID in $PIDS; do
   then
     INSTANCE_UUID=$(virsh dumpxml $INSTANCE_NAME|grep \/uuid|awk -F'>' "{print \$2}"|awk -F'<' "{print \$1}")
     echo $INSTANCE_UUID
+    #INSTANCE_QEMU_MON_RBD_COUNT=$(virsh qemu-monitor-command --hmp "$INSTANCE_NAME" 'info block'|grep -c rbd)
+    #echo "DEBUG: $INSTANCE_UUID has $INSTANCE_QEMU_MON_RBD_COUNT RBD devices configured"
   fi
 done
 

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -9,7 +9,7 @@ DEBUG=1
 
 usage() { echo "Usage: $0 [-o 10] [-n 12] [-e] [-d]" 1>&2; exit 1; }
 
-while getopts ":o:n:rh" arg; do
+while getopts ":o:n:edh" arg; do
   case $arg in
     o)
        CEPH_MAJORVER_EXPECTED_OLD=$OPTARG

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -13,32 +13,46 @@ if [ -z ${CEPH_MAJORVER_EXPECTED_NEW+x} ]; then
   CEPH_MAJORVER_EXPECTED_NEW=$2
 fi
 
-YUM_HISTORY_EVENTS=$(yum history|grep -E '^  '|awk '{print $1}')
+# Retrieve a list of all yum history event IDs
+YUM_HISTORY_EVENTS=$(yum history list all|grep -Po "^\s+\d+")
 
 for YUM_HISTORY_EVENT in $YUM_HISTORY_EVENTS; do
   CEPH_MAJORVER_OLD=$(yum history info $YUM_HISTORY_EVENT|grep -A1 ceph-common|head -1|awk -F':' '{print $2}'|awk -F'.' '{print $1}')
   CEPH_MAJORVER_NEW=$(yum history info $YUM_HISTORY_EVENT|grep -A1 ceph-common|tail -1|awk -F':' '{print $2}'|awk -F'.' '{print $1}')
+  # See if this event matches the upgrade path we're looking for
   if [[ "$CEPH_MAJORVER_OLD" == "$CEPH_MAJORVER_EXPECTED_OLD" ]] && [[ "$CEPH_MAJORVER_NEW" == "$CEPH_MAJORVER_EXPECTED_NEW" ]]
   then
+    # It did, so mark down event time
     CEPH_UPGRADE_DATE=$(yum history info $YUM_HISTORY_EVENT|grep '^Begin time'|awk -F' : ' '{print $2}')
     CEPH_UPGRADE_TIMESTAMP=$(date -d "$CEPH_UPGRADE_DATE" +%s)
     break
   fi
 done
 
+# Retrieve a list of all QEMU process IDs
 PIDS=$(pidof /usr/libexec/qemu-kvm)
 
 for PID in $PIDS; do
+  # Get QEMU process start time
   QEMU_TIMESTAMP=$(date -d "$(stat -c %x /proc/$PID/stat)" +%s)
+  # Get virsh instance name
   INSTANCE_NAME=$(ps -ef -q $PID|grep -Po "(instance-\w+)"|uniq)
+  # Look for presence of block devices with "rbd" driver (as opposed to "raw" for local)
   INSTANCE_QEMU_MON_RBD=$(virsh qemu-monitor-command --hmp "$INSTANCE_NAME" 'info block'|grep rbd)
+  # Save return code for determining if rbd's were present
   INSTANCE_USE_RBD=$?
+  # If QEMU process has been running before the Ceph upgrade and instance uses a RBD driver,
+  # then with rather good probability it's running the old Ceph client version.
   if [[ "$QEMU_TIMESTAMP" -lt "$CEPH_UPGRADE_TIMESTAMP" ]] && [ "$INSTANCE_USE_RBD" -eq "0" ]
   then
+    # Print out the instance UUID for further processing
     INSTANCE_UUID=$(virsh dumpxml $INSTANCE_NAME|grep \/uuid|awk -F'>' "{print \$2}"|awk -F'<' "{print \$1}")
     echo $INSTANCE_UUID
+    # The following two lines can be uncommented if one is also interested about the overall
+    # number of RBDs (volume attachments), since that seems to correlate best to the number
+    # of clients that ceph-mgr is seeing.
     #INSTANCE_QEMU_MON_RBD_COUNT=$(virsh qemu-monitor-command --hmp "$INSTANCE_NAME" 'info block'|grep -c rbd)
-    #echo "DEBUG: $INSTANCE_UUID has $INSTANCE_QEMU_MON_RBD_COUNT RBD devices configured"
+    #echo "DEBUG: $INSTANCE_UUID has this many RBD devices configured: $INSTANCE_QEMU_MON_RBD_COUNT"
   fi
 done
 

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+# Managed with Ansible
 
-# By default, search for upgrades from Jewel to Luminous.
+# DEFAULTS
+# Search for upgrades from Jewel to Luminous.
 CEPH_MAJORVER_EXPECTED_OLD=10
 CEPH_MAJORVER_EXPECTED_NEW=12
-# By default, include VMs which do not have RBD block devices attached.
-INCLUDE_QEMU_WITHOUT_RBD=0
-# By default, no debug
+# QEMUs with no Rados Block Devices (RBD) are included in the results.
+EXCLUDE_QEMU_WITHOUT_RBD=1
+# No debug logging.
 DEBUG=1
 
 usage() {
@@ -13,7 +15,7 @@ usage() {
   echo "" 1>&2;
   echo "  -o, expected old ceph version" 1>&2;
   echo "  -n, expected new ceph version" 1>&2;
-  echo "  -e, exclude QEMUs with no RBDs present" 1>&2;
+  echo "  -e, exclude QEMUs with no RBDs" 1>&2;
   echo "  -d, debug" 1>&2;
   echo "" 1>&2;
   exit 1
@@ -28,7 +30,7 @@ while getopts ":o:n:edh" arg; do
        CEPH_MAJORVER_EXPECTED_NEW=$OPTARG
        ;;
     e)
-       INCLUDE_QEMU_WITHOUT_RBD=1
+       EXCLUDE_QEMU_WITHOUT_RBD=0
        ;;
     d)
        DEBUG=0
@@ -71,8 +73,8 @@ for PID in $PIDS; do
   # Check if instance did NOT have RBDs
   if [[ "$INSTANCE_HAS_RBD" -ne "0" ]]
   then
-    # Check if we should not report on these type of instances
-    if [[ "$INCLUDE_QEMU_WITHOUT_RBD" -ne "0" ]]
+    # Check if these type of instances should be excluded from search results
+    if [[ "$EXCLUDE_QEMU_WITHOUT_RBD" -eq "0" ]]
     then
       break
     fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   tags: script
   no_log: true
 - name: Run verification script
-  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_qemu_without_rbd else '' }}" "{{ '-d' if script_debug_output else '' }}"
+  shell: "/root/ceph-version-qemu.sh {{ '-e' if exclude_qemu_without_rbd else '' }} {{ '-d' if script_debug_output else '' }}"
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   tags: script
   no_log: true
 - name: Run verification script
-  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_no_rbd=='true' else '' }}" "{{ '-d' if script_debug=='true' else '' }}"
+  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_qemu_without_rbd else '' }}" "{{ '-d' if script_debug_output else '' }}"
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   tags: script
   no_log: true
 - name: Run verification script
-  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_rbd=='true' else '' }}" "{{ '-d' if script_debug=='true' else '' }}"
+  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_no_rbd=='true' else '' }}" "{{ '-d' if script_debug=='true' else '' }}"
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   tags: script
   no_log: true
 - name: Run verification script
-  shell: /root/ceph-version-qemu.sh
+  shell: /root/ceph-version-qemu.sh "{{ (script_debug == true) | ternary('-d','') }}"
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   tags: script
   no_log: true
 - name: Run verification script
-  shell: /root/ceph-version-qemu.sh "{{ (script_debug == true) | ternary('-d','') }}"
+  shell: /root/ceph-version-qemu.sh "{{ '-e' if exclude_rbd=='true' else '' }}" "{{ '-d' if script_debug=='true' else '' }}"
   changed_when: False

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for ansible-role-qemu-ceph-clients
 script_debug: false
-exclude_rbd: false
+exclude_no_rbd: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for ansible-role-qemu-ceph-clients
 script_debug: false
+exclude_rbd: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,2 @@
 ---
 # vars file for ansible-role-qemu-ceph-clients
-script_debug: false
-exclude_no_rbd: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for ansible-role-qemu-ceph-clients
+script_debug: false


### PR DESCRIPTION
When iterating qemu PIDs, verify from the qemu monitor 'info block'
section that rbd driver is really being used for any of the VM disks.