### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: python
+
+sudo: required
+dist: trusty
+group: edge
+
+services:
+  - docker
+
+matrix:
+  fast_finish: true
+
+env:
+  - IMAGE_BUILD_PLATFORM=ansible-pip-centos7
+  - IMAGE_BUILD_PLATFORM=ansible-master-github-centos7
+
+install:
+  - npm install -g validate-dockerfile
+before_script:
+  # TESTDIR = Where the stable-centos/Dockerfile is located
+  - export TESTDIR=tests
+  # ROLETOTEST = The name of this repo
+  - export ROLETOTEST=$(basename $(pwd))
+  - export COMMIT=${TRAVIS_COMMIT::8}
+  # The tag we assign the docker image we build with the Dockerfile
+  - export REPO=csc/ansible
+  # https://www.npmjs.com/package/validate-dockerfile - validate the Dockerfile
+  - docklint ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/Dockerfile
+  # Build the image
+  - docker build -t ${REPO}:${IMAGE_BUILD_PLATFORM} ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/
+  # Launch the container
+  - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+
+script:
+  # Testing of this ansible-role:
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh $IMAGE_BUILD_PLATFORM"
+after_script:
+  - >
+    docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";
+       systemctl --no-pager --all --full status ;
+       echo -ne "------\nJournalD Logs:\n------\n" ;
+       sudo journalctl --catalog --all --full --no-pager'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /ansible*'
+  - docker ps -a
+  - docker stop $DOCKER_CONTAINER_ID
+  - docker rm -v $DOCKER_CONTAINER_ID
+
+notifications:
+  email: false
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/CSCfi/ansible-role-qemu-ceph-clients.svg?branch=master)](https://travis-ci.com/CSCfi/ansible-role-qemu-ceph-clients)
+
 ansible-role-qemu-ceph-clients
 =========
 
@@ -6,17 +8,12 @@ Detect qemu process ceph client version staleness
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+None
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
-
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+See defaults/main.yml
 
 Example Playbook
 ----------------
@@ -25,14 +22,13 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: ansible-role-qemu-ceph-clients, exclude_qemu_without_rbd: True }
 
 License
 -------
 
-BSD
+MIT
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: MIT
 
   min_ansible_version: 1.2
 

--- a/tests/ansible-master-github-centos7/Dockerfile
+++ b/tests/ansible-master-github-centos7/Dockerfile
@@ -1,0 +1,42 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum makecache all && \
+    yum -y groups mark convert && \
+    yum -y groups mark install "Development Tools" && \
+    yum -y groups mark convert "Development Tools" && \
+    yum -y groupinstall "Development Tools" && \
+    yum -y install libffi-devel openssl-devel && \
+    yum -y install dbus-devel dbus-python-devel dbus dbus-glib dbus-glib-devel && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
+    pip install passlib dnspython && \
+    sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost\n' > /etc/ansible/hosts
+RUN mkdir /opt/ansible/
+RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
+WORKDIR /opt/ansible/ansible
+# here one could checkout a specific commit
+#RUN git checkout f4af154beff2b281e464b616f504293d67187da5
+RUN git submodule update --init
+ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
+ENV PYTHONPATH /opt/ansible/ansible/lib
+ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library
+# Workaround bug in pip / pylockfile: http://pad.lv/1472101
+# If HOME is a volume mount, causes infinite loop in pip trying to write lock
+ENV XDG_CACHE_HOME /tmp/
+RUN source /opt/ansible/ansible/hacking/env-setup
+
+
+CMD /bin/bash

--- a/tests/ansible-pip-centos7/Dockerfile
+++ b/tests/ansible-pip-centos7/Dockerfile
@@ -1,0 +1,21 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+CMD ["/bin/bash"]

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
-localhost
-
+localhost ansible_connection=local

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -115,8 +115,8 @@ function test_playbook(){
     echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
 
-#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+RDIR="$( dirname "$SOURCE" )"
+SUDO=`which sudo 2> /dev/null`
+SUDO_OPTION=""
+#SUDO_OPTION="--sudo"
+OS_TYPE=${1:-}
+OS_VERSION=${2:-}
+ANSIBLE_VERSION=${3:-}
+
+# So if we get fgcislurm as the first bash argument to this script we
+#  change playbook to a slurm specific version.
+# This means to test a new SLURM version we need to add a new playbook.
+if [[ $OS_TYPE = *"fgcislurm"* ]]; then
+  ANSIBLE_VAR=""
+  SLURMVERSION=$(echo $OS_TYPE|tr -d 'fgcislurm')
+  ANSIBLE_PLAYBOOk="tests/test$SLURMVERSION.yml"
+else
+  ANSIBLE_VAR=""
+  ANSIBLE_PLAYBOOk="tests/test.yml"
+fi
+ANSIBLE_INVENTORY="tests/inventory"
+#ANSIBLE_LOG_LEVEL=""
+ANSIBLE_LOG_LEVEL="-v"
+
+# if there wasn't sudo then ansible couldn't use it
+if [ "x$SUDO" == "x" ];then
+    SUDO_OPTION=""
+fi
+
+ANSIBLE_EXTRA_VARS=""
+if [ "${ANSIBLE_VAR}x" != "x" ];then
+    ANSIBLE_EXTRA_VARS=" -e \"${ANSIBLE_VAR}\" "
+fi
+
+
+cd $RDIR/..
+printf "[defaults]\nroles_path = ../:roles" > ansible.cfg
+printf "" > ssh.config
+
+function show_version() {
+
+echo "TEST: show versions"
+ansible --version
+id
+systemctl --no-pager
+proc1comm=$(cat /proc/1/comm)
+echo "TEST: proc1s comm is $proc1comm"
+
+}
+
+function install_ansible_devel() {
+
+# http://docs.ansible.com/ansible/intro_installation.html#latest-release-via-yum
+
+echo "TEST: building ansible"
+
+yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch wget 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
+rm -Rf ansible
+git clone https://github.com/ansible/ansible --recursive ||(echo "Could not clone ansible from Github" && exit 2 )
+cd ansible
+# checking out this commit because some errors after 2015-11-05
+#git checkout 07d0d2720c73816e1206882db7bc856087eb5c3f
+# because systemctl and systemd
+git checkout 589971fe7ef78ea8bb41fb9ae6cd19cb8e277371
+make rpm 2>&1 >/dev/null
+rpm -Uvh ./rpm-build/ansible-*.noarch.rpm ||(echo "Could not install built ansible devel rpms" && exit 2 )
+cd ..
+rm -Rf ansible
+
+}
+
+function install_os_deps() {
+echo "TEST: installing os deps"
+
+yum -y install epel-release sudo tree git which file less||(echo "Could not install some os deps" && exit 2 )
+
+}
+
+function tree_list() {
+
+tree
+
+}
+function test_ansible_setup(){
+    echo "TEST: ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost"
+
+    ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost
+
+}
+
+
+function test_install_requirements(){
+    echo "TEST: ansible-galaxy install -r requirements.yml --force"
+
+    ansible-galaxy install -r requirements.yml --force ||(echo "requirements install failed" && exit 2 )
+
+}
+
+function test_playbook_syntax(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check ||(echo "ansible playbook syntax check was failed" && exit 2 )
+}
+
+function test_playbook_check(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check ||(echo "playbook check failed" && exit 2 )
+
+}
+
+function test_playbook(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
+
+#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+}
+function extra_tests(){
+
+    echo "TEST: cat /etc/slurm/slurm.conf"
+    cat /etc/slurm/slurm.conf
+
+}
+
+
+set -e
+function main(){
+#    install_os_deps
+#    install_ansible_devel
+    show_version
+#    tree_list
+#    test_install_requirements
+    test_ansible_setup
+    tree_list
+    test_playbook_syntax
+    test_playbook
+    test_playbook_check
+#    extra_tests
+
+}
+
+################ run #########################
+main

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,10 @@
 - hosts: all
   remote_user: root
   become: true
+  pre_tasks:
+    - name: install dependencies not available in centos docker image
+      package:
+        name: "{{ 'sysvinit-utils' if ansible_os_family == 'Debian' else 'sysvinit-tools' }}"
+        state: installed
   roles:
     - ansible-role-qemu-ceph-clients

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- hosts: all
   remote_user: root
+  become: true
   roles:
     - ansible-role-qemu-ceph-clients


### PR DESCRIPTION
Worth noting is that if pidof is not found there's an error but the script returns code 0.
This PR installs sysvinit-tools (or sysvinit-utils on Debian) - but only as part of testing because a minimal centos7 install should have it (the docker centos7 image is more minimal than the minimal...).
It could quite easily be moved into the main task file of desired.

```json
ok: [localhost] => {"changed": false, "cmd": "/root/ceph-version-qemu.sh  ", "delta": "0:00:05.049010", "end": "2019-03-15 06:13:53.126090", "rc": 0, "start": "2019-03-15 06:13:48.077080", "stderr": "/root/ceph-version-qemu.sh: line 62: pidof: command not found", "stderr_lines": ["/root/ceph-version-qemu.sh: line 62: pidof: command not found"], "stdout": "", "stdout_lines": []}
```