### PR TITLE
CCCP-3802: Limit the exclude of RBD to VMs rather than servers

### DIFF
--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -73,10 +73,10 @@ for PID in $PIDS; do
   # Check if instance did NOT have RBDs
   if [[ "$INSTANCE_HAS_RBD" -ne "0" ]]
   then
-    # Check if these type of instances should be excluded from search results
+    # Check if this type of instance should be excluded from search results
     if [[ "$EXCLUDE_QEMU_WITHOUT_RBD" -eq "0" ]]
     then
-      break
+      continue
     fi
   fi
 


### PR DESCRIPTION
In the current version of the code, when a VM is detected does not have
an RBD and the flag exclude_qemu_without_rbd is set, the script omit to
check other VMs in the server. This fix allows to list all the VMs that
have RBD in a server that has a VM without rbd and the flag
exclude_qemu_without_rbd is set.