### PR TITLE
CCCP-3821: Prevent the use of pidof when listing qemu process

### DIFF
--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -62,8 +62,7 @@ done
 # The pidof command can be used when this bug is fixed 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926896
 # PIDS=$(pidof /usr/libexec/qemu-kvm)
-PIDS=$(ps aux | grep qemu| awk -F' ' '{print $2}'| tail -n +2)
-
+PIDS=$(ps aux | grep -v root |  grep qemu| awk -F' ' '{print $2}')
 
 for PID in $PIDS; do
   # Get QEMU process start time

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -59,10 +59,7 @@ for YUM_HISTORY_EVENT in $YUM_HISTORY_EVENTS; do
 done
 
 # Retrieve a list of all QEMU process IDs
-# The pidof command can be used when this bug is fixed 
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926896
-# PIDS=$(pidof /usr/libexec/qemu-kvm)
-PIDS=$(ps aux | grep -v root |  grep qemu| awk -F' ' '{print $2}')
+PIDS=$(pgrep -f /usr/libexec/qemu-kvm)
 
 for PID in $PIDS; do
   # Get QEMU process start time

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -59,7 +59,11 @@ for YUM_HISTORY_EVENT in $YUM_HISTORY_EVENTS; do
 done
 
 # Retrieve a list of all QEMU process IDs
-PIDS=$(pidof /usr/libexec/qemu-kvm)
+# The pidof command can be used when this bug is fixed 
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926896
+# PIDS=$(pidof /usr/libexec/qemu-kvm)
+PIDS=$(ps aux | grep qemu| awk -F' ' '{print $2}'| tail -n +2)
+
 
 for PID in $PIDS; do
   # Get QEMU process start time

--- a/files/ceph-version-qemu.sh
+++ b/files/ceph-version-qemu.sh
@@ -59,7 +59,7 @@ for YUM_HISTORY_EVENT in $YUM_HISTORY_EVENTS; do
 done
 
 # Retrieve a list of all QEMU process IDs
-PIDS=$(pgrep -f /usr/libexec/qemu-kvm)
+PIDS=$(pgrep -f "^/usr/libexec/qemu-kvm")
 
 for PID in $PIDS; do
   # Get QEMU process start time

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,3 +11,8 @@
 - name: Run verification script
   shell: "/root/ceph-version-qemu.sh {{ '-e' if exclude_qemu_without_rbd else '' }} {{ '-d' if script_debug_output else '' }}"
   changed_when: False
+
+- name: Clean verification script
+  ansible.builtin.file:
+    path: /root/ceph-version-qemu.sh
+    state: absent


### PR DESCRIPTION
There is a bug in the use of pidof. In some cases, pidof don't list all
the process. In this patch, we use ps instead pidof. Later, the code can
use pidof when the bug is fixed.